### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/tadeosun260603/6ad7df39-2821-497f-8252-a85b17b60be0/8fa61f90-042f-4cb3-bfc2-4aec6911a38a/_apis/work/boardbadge/a09583f8-7db3-43d0-acc0-4a3f227e450b)](https://dev.azure.com/tadeosun260603/6ad7df39-2821-497f-8252-a85b17b60be0/_boards/board/t/8fa61f90-042f-4cb3-bfc2-4aec6911a38a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tadeosun260603/6ad7df39-2821-497f-8252-a85b17b60be0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.